### PR TITLE
feat(plugins): Restore plug-ins as assets

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -270,12 +270,14 @@ handle_che_theia() {
   
   # post-install dependencies
   # /home/theia-dev/theia-source-code/packages/debug-nodejs/download = node debug vscode binary
+  # /home/theia-dev/theia-source-code/plugins/ = VS Code extensions
   # /tmp/vscode-ripgrep-cache-1.2.4 /tmp/vscode-ripgrep-cache-1.5.7 = rigrep binaries
   # /home/theia-dev/.cache = include electron/node-gyp cache
   docker run --rm --entrypoint= ${TMP_THEIA_BUILDER_IMAGE} ls -la /tmp/vscode-ripgrep-cache*
   docker run --rm --entrypoint= ${TMP_THEIA_BUILDER_IMAGE} tar -pzcf - \
     /home/theia-dev/theia-source-code/packages/debug-nodejs/download  \
     /tmp/vscode-ripgrep-cache-* \
+    /home/theia-dev/theia-source-code/plugins/  \
     /home/theia-dev/.cache > asset-post-download-dependencies.tar.gz
   
   # node-headers


### PR DESCRIPTION
Keep cache of plug-ins to avoid to download them
Target CRW-643

NB: I'm unable to test as the build scripts assume some stuff on the local computer
like
```
$  docker run --rm --entrypoint= ${TMP_THEIA_BUILDER_IMAGE} ls -la /tmp/vscode-ripgrep-cache*
```
where * is interpreted before executing the command, etc