### PR TITLE
Support encrypted SSH private keys

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -400,7 +400,7 @@ handle_che_theia() {
     /opt/app-root/src/.npm-global' > asset-yarn-runtime-image.tar.gz
 
   # Save sshpass sources
-  ${DOCKERRUN} run --rm --entrypoint sh ${TMP_THEIA_RUNTIME_IMAGE} -c 'cat /opt/app-root/src/sshpass.tar.gz' > asset-sshpass.tar.gz
+  ${DOCKERRUN} run --rm --entrypoint sh ${TMP_THEIA_RUNTIME_IMAGE} -c 'cat /opt/app-root/src/sshpass.tar.gz' > asset-sshpass-sources.tar.gz
 
   rm -rf src
   cp -r "${DOCKERFILES_ROOT_DIR}"/theia/src .

--- a/build.sh
+++ b/build.sh
@@ -399,6 +399,9 @@ handle_che_theia() {
     /usr/local/share/.cache/yarn/v*/ \
     /opt/app-root/src/.npm-global' > asset-yarn-runtime-image.tar.gz
 
+  # Save sshpass sources
+  ${DOCKERRUN} run --rm --entrypoint sh ${TMP_THEIA_RUNTIME_IMAGE} -c 'cat /opt/app-root/src/sshpass.tar.gz' > asset-sshpass.tar.gz
+
   rm -rf src
   cp -r "${DOCKERFILES_ROOT_DIR}"/theia/src .
   

--- a/conf/theia/ubi8-brew/runtime-install-dependencies.dockerfile
+++ b/conf/theia/ubi8-brew/runtime-install-dependencies.dockerfile
@@ -8,7 +8,7 @@ USER root
 # Install curl and bash
 # Install ssh for cloning ssh-repositories
 # Install sshpass for handling passwordds for SSH keys
-RUN yum install -y sudo git bzip2 which bash curl openssh less \
-    wget http://sourceforge.net/projects/sshpass/files/latest/download -O sshpass.tar.gz && \
-    tar -xvf sshpass.tar.gz && cd sshpass-1.06 && ./configure && make install cd .. && rm -rf sshpass-1.06 && \
+RUN yum install -y sudo git bzip2 which bash curl openssh less && \
+    wget http://sourceforge.net/projects/sshpass/files/latest/download -O sshpass.tar.gz && tar -xvf sshpass.tar.gz && \
+    cd sshpass-1.06 && ./configure && sudo make install && cd .. && rm -rf sshpass-1.06 && rm sshpass.tar.gz && \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"

--- a/conf/theia/ubi8-brew/runtime-install-dependencies.dockerfile
+++ b/conf/theia/ubi8-brew/runtime-install-dependencies.dockerfile
@@ -7,7 +7,8 @@ USER root
 # Install which tool in order to search git
 # Install curl and bash
 # Install ssh for cloning ssh-repositories
-# Install less for handling git diff properly
-RUN yum install -y sudo bzip2 git which bash curl openssh less && \
-    yum -y clean all && rm -rf /var/cache/yum && \
+# Install sshpass for handling passwordds for SSH keys
+RUN yum install -y sudo git bzip2 which bash curl openssh less \
+    wget http://sourceforge.net/projects/sshpass/files/latest/download -O sshpass.tar.gz && \
+    tar -xvf sshpass.tar.gz && cd sshpass-1.06 && ./configure && make install cd .. && rm -rf sshpass-1.06 && \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"

--- a/conf/theia/ubi8-brew/runtime-install-dependencies.dockerfile
+++ b/conf/theia/ubi8-brew/runtime-install-dependencies.dockerfile
@@ -1,14 +1,17 @@
 # need root user
 USER root
 
+# Copy sshpass sources
+COPY asset-sshpass.tar.gz /tmp/
+
 # Install sudo
 # Install bzip2 to unpack files
 # Install git
 # Install which tool in order to search git
 # Install curl and bash
 # Install ssh for cloning ssh-repositories
-# Install sshpass for handling passwordds for SSH keys
-RUN yum install -y sudo git bzip2 which bash curl openssh less && \
-    wget http://sourceforge.net/projects/sshpass/files/latest/download -O sshpass.tar.gz && tar -xvf sshpass.tar.gz && \
-    cd sshpass-1.06 && ./configure && sudo make install && cd .. && rm -rf sshpass-1.06 && rm sshpass.tar.gz && \
+# Install less for handling git diff properly
+# Install sshpass for handling passwords for SSH keys
+RUN yum install -y sudo git bzip2 which bash curl openssh less && tar -xvf /tmp/asset-sshpass.tar.gz && \
+    cd /tmp/sshpass-1.06 && ./configure && make install && cd .. && rm -rf sshpass-1.06 && rm sshpass.tar.gz && \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"

--- a/conf/theia/ubi8-brew/runtime-install-dependencies.dockerfile
+++ b/conf/theia/ubi8-brew/runtime-install-dependencies.dockerfile
@@ -2,7 +2,7 @@
 USER root
 
 # Copy sshpass sources
-COPY asset-sshpass.tar.gz /tmp/
+COPY asset-sshpass-sources.tar.gz /tmp/
 
 # Install sudo
 # Install bzip2 to unpack files
@@ -12,6 +12,6 @@ COPY asset-sshpass.tar.gz /tmp/
 # Install ssh for cloning ssh-repositories
 # Install less for handling git diff properly
 # Install sshpass for handling passwords for SSH keys
-RUN yum install -y sudo git bzip2 which bash curl openssh less && tar -xvf /tmp/asset-sshpass.tar.gz && \
-    cd /tmp/sshpass-*/ && ./configure && make install && cd .. && rm -rf sshpass-* && \
+RUN yum install -y sudo git bzip2 which bash curl openssh less && tar -xvf /tmp/asset-sshpass-sources.tar.gz && \
+    cd /tmp/sshpass-*/ && ./configure && make install && cd /tmp && rm -rf *sshpass-* && \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"

--- a/conf/theia/ubi8-brew/runtime-install-dependencies.dockerfile
+++ b/conf/theia/ubi8-brew/runtime-install-dependencies.dockerfile
@@ -13,5 +13,5 @@ COPY asset-sshpass.tar.gz /tmp/
 # Install less for handling git diff properly
 # Install sshpass for handling passwords for SSH keys
 RUN yum install -y sudo git bzip2 which bash curl openssh less && tar -xvf /tmp/asset-sshpass.tar.gz && \
-    cd /tmp/sshpass-1.06 && ./configure && make install && cd .. && rm -rf sshpass-1.06 && rm sshpass.tar.gz && \
+    cd /tmp/sshpass-*/ && ./configure && make install && cd .. && rm -rf sshpass-* && \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
When uploading an encrypted SSH private key, ask a password for the key and register the key by executing ssh-add command. On the SSH plugin start iterate through the registered ssh keys and if a private key is encrypted read the passphrase from the key and register it with the help of ssh-add.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16517
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
