### PR TITLE
remove x86 qualifier from package name to work on multiple arches

### DIFF
--- a/conf/theia-endpoint-runtime-binary/ubi8-brew/builder-setup.dockerfile
+++ b/conf/theia-endpoint-runtime-binary/ubi8-brew/builder-setup.dockerfile
@@ -6,5 +6,5 @@ RUN tar xzf /tmp/asset-theia-endpoint-runtime-binary-yarn.tar.gz -C / && rm -f /
     export NODE_VERSION=$(node --version | sed -s 's/v//') && mkdir -p "/home/theia/.nexe/${NODE_VERSION}" && tar zxf /tmp/asset-node-src.tar.gz --strip-components=1 -C "/home/theia/.nexe/${NODE_VERSION}" && \
     tar zxf /tmp/asset-theia-endpoint-runtime-pre-assembly-nodejs-static.tar.gz -C "/home/theia/"
 
-RUN yum install -y git make cmake gcc gcc-c++ python2 automake autoconf which glibc-devel.x86_64 && \
+RUN yum install -y git make cmake gcc gcc-c++ python2 automake autoconf which glibc-devel && \
     yum -y clean all && rm -rf /var/cache/yum && ln -s /usr/bin/python2 /usr/bin/python


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

remove x86 qualifier from package name to work on multiple arches

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
