### PR TITLE
force install of yq, even if installed globally

### DIFF
--- a/sources.Jenkinsfile
+++ b/sources.Jenkinsfile
@@ -325,7 +325,7 @@ timeout(120) {
   node(nodeLabel) {
     stage ("Sync repos on ${nodeLabel}") {
       wrap([$class: 'TimestamperBuildWrapper']) {
-        sh('pip install --user yq')
+        sh('pip install -I --user yq')
         yq_bin = sh(script: 'python -m site --user-base', returnStdout:true).trim() + '/bin/yq'
         echo "currentBuild.result = " + currentBuild.result
         if (!currentBuild.result.equals("ABORTED") && !currentBuild.result.equals("FAILED")) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?

force install of yq, even if installed globally

### What issues does this PR fix or reference?
12:09:27 + pip install --user yq
12:09:29 Requirement already satisfied: yq in /usr/local/lib/python3.6/site-packages (2.11.0)
12:09:29 Requirement already satisfied: xmltodict>=0.11.0 in /usr/local/lib/python3.6/site-packages (from yq) (0.12.0)
12:09:29 Requirement already satisfied: argcomplete>=1.8.1 in /usr/local/lib/python3.6/site-packages (from yq) (1.12.0)
12:09:29 Requirement already satisfied: PyYAML>=3.11 in /usr/local/lib64/python3.6/site-packages (from yq) (5.3.1)
12:09:29 Requirement already satisfied: setuptools in /usr/lib/python3.6/site-packages (from yq) (39.2.0)
12:09:29 Requirement already satisfied: importlib-metadata<2,>=0.23; python_version == "3.6" in /usr/local/lib/python3.6/site-packages (from argcomplete>=1.8.1->yq) (1.7.0)
12:09:29 Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.6/site-packages (from importlib-metadata<2,>=0.23; python_version == "3.6"->argcomplete>=1.8.1->yq) (3.1.0)
...
12:10:16 /mnt/hudson_workspace/workspace/crw-theia-sources_2.4@tmp/durable-48665d66/script.sh: line 100: /home/hudson/.local/bin/yq: No such file or directory

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
