### PR TITLE
fix: Fix dialog title to display CodeReady Workspaces instead of Eclipse Che

### DIFF
--- a/build/scripts/collect-assets.sh
+++ b/build/scripts/collect-assets.sh
@@ -268,6 +268,7 @@ collect_noarch_assets_crw_theia_dev() {
   pushd "$cheTheiaSourcesDir" >/dev/null || exit 1
     git clone https://github.com/eclipse-che/che-theia
     cd che-theia && git checkout $SOURCE_BRANCH
+    sed -i 's|Eclipse Che|CodeReady Workspaces|g' ./generator/src/templates/assembly-package.mst.json
     cd generator && yarn && yarn pack --filename "${TARGETDIR}"/asset-eclipse-che-theia-generator.tgz
   popd >/dev/null || exit 1
   rm -fr "${cheTheiaSourcesDir}"


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Override the `applicationName` value (`Eclipse Che`) from the [upstream Eclipse Che-theia](https://github.com/eclipse-che/che-theia/blob/e95922f4d6ea26e1281762344d8fc1e122112920/generator/src/templates/assembly-package.mst.json#L8) to `CodeReady Workspaces`. This value is used as a dialog title.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2718

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
